### PR TITLE
fix: handle ESC key to close plugin as advertised in the UI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,9 @@ impl ZellijPlugin for State {
                             self.sequential_commands_to_run.run_next_commnand();
                         }
                     }
+                    BareKey::Esc if key.has_no_modifiers() => {
+                        close_self();
+                    }
                     _ => {}
                 }
             }
@@ -326,4 +329,3 @@ impl State {
         }
     }
 }
-


### PR DESCRIPTION
The plugin's help text at the bottom of the screen already advertises `<ESC> - close`. However, the update function had no handler for the Esc key event, so pressing ESC did nothing.

I added a `BareKey::Esc` arm to the match block that calls `close_self()`, making the plugin behave as the UI hint describes.

Note that the newer version of rustup changed the target name to `wasm32-wasip1`.